### PR TITLE
refactor(network): use declarative instead of scripted network config

### DIFF
--- a/hosts/shared/nix.nix
+++ b/hosts/shared/nix.nix
@@ -30,6 +30,6 @@
   };
 
   system = {
-    stateVersion = "24.11";
+    stateVersion = "25.05";
   };
 }


### PR DESCRIPTION
Additionally I've dropped the opened incoming TCP ports, added the IPv6 DNS server equivalents and introduced MAC address spoofing as an additional privacy feature.

I'm currently using NixOS on a laptop and I haven't included a separate module for a wired situation. That's trivial to set up though now that I have a deeper understanding of systemd-networkd.