### PR TITLE
Video 4 Linux virtual video devices support

### DIFF
--- a/hosts/luna/default.nix
+++ b/hosts/luna/default.nix
@@ -57,6 +57,7 @@ in
     sound.enable = true;
     openssh.enable = true;
     steam.enable = true;
+    v4l2loopback.enable = true;
     wayland.enable = true;
     # yubikey.enable = true;
   };

--- a/modules/.gitkeep
+++ b/modules/.gitkeep
@@ -1,9 +1,9 @@
-{config, lib, ...}:
+{ config, lib, ... }:
 
 let
   cfg = config.host.PLACEHOLDER;
 in
-  with lib;
+with lib;
 {
   options = {
     host.PLACEHOLDER.enable = mkEnableOption "PLACEHOLDER";

--- a/modules/steam.nix
+++ b/modules/steam.nix
@@ -16,7 +16,7 @@ with lib;
     programs = {
       steam = {
         enable = true;
-        dedicatedServer.openFirewall = true;
+        dedicatedServer.openFirewall = false;
         localNetworkGameTransfers.openFirewall = true;
         protontricks.enable = true;
         remotePlay.openFirewall = true;

--- a/modules/v4l2loopback.nix
+++ b/modules/v4l2loopback.nix
@@ -1,0 +1,23 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.host.v4l2loopback;
+in
+with lib;
+{
+  options = {
+    host.v4l2loopback.enable = mkEnableOption "v4l2loopback virtual video devices";
+  };
+
+  config = mkIf cfg.enable {
+    boot = {
+      extraModulePackages = with config.boot.kernelPackages; [
+        v4l2loopback
+      ];
+      extraModprobeConfig = ''
+        options v4l2loopback devices=1 video_nr=1 card_label="Virtual Camera" exclusive_caps=1
+      '';
+      kernelModules = [ "v4l2loopback" ];
+    };
+  };
+}


### PR DESCRIPTION
This allows me to use a phone camera as a webcam in for example OBS by capturing it with `scrcpy` and sinking it into `/dev/video1`.