### PR TITLE
Add support for kubernetes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741786315,
-        "narHash": "sha256-VT65AE2syHVj6v/DGB496bqBnu1PXrrzwlw07/Zpllc=",
+        "lastModified": 1753140376,
+        "narHash": "sha256-7lrVrE0jSvZHrxEzvnfHFE/Wkk9DDqb+mYCodI5uuB8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "0d8c6ad4a43906d14abd5c60e0ffe7b587b213de",
+        "rev": "545aba02960caa78a31bd9a8709a0ad4b6320a5c",
         "type": "github"
       },
       "original": {
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742937932,
-        "narHash": "sha256-OrLDssbhEZvbHMljgT2mFNWacghm2HJBDTWlqTJNhO8=",
+        "lastModified": 1753822434,
+        "narHash": "sha256-yNjk/R2ca+rQm6PWzwKpa+MZZGkNnr6Y8rBf+ZZ6ICo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f565da89e759ebf57b236510aa955b8a2d41c779",
+        "rev": "909d39391efa9a1f74f7386cb6919b2722e06310",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742669843,
-        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
+        "lastModified": 1753694789,
+        "narHash": "sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
+        "rev": "dc9637876d0dcc8c9e5e22986b857632effeb727",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742700801,
-        "narHash": "sha256-ZGlpUDsuBdeZeTNgoMv+aw0ByXT2J3wkYw9kJwkAS4M=",
+        "lastModified": 1752544651,
+        "narHash": "sha256-GllP7cmQu7zLZTs9z0J2gIL42IZHa9CBEXwBY9szT0U=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "67566fe68a8bed2a7b1175fdfb0697ed22ae8852",
+        "rev": "2c8def626f54708a9c38a5861866660395bb3461",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
     {
       nixpkgs,
       self,
+      disko,
       sops-nix,
       ...
     }@inputs:
@@ -65,13 +66,16 @@
         args:
         nixpkgs.lib.nixosSystem {
           modules = [
+            disko.nixosModules.disko
             sops-nix.nixosModules.sops
             (import ./modules)
             (import ./users)
-          ] ++ args.modules;
+          ]
+          ++ args.modules;
           specialArgs = {
             inherit self inputs outputs;
-          } // (args.specialArgs or { });
+          }
+          // (args.specialArgs or { });
         };
     in
     {

--- a/hosts/luna/default.nix
+++ b/hosts/luna/default.nix
@@ -56,10 +56,14 @@ in
     avahi.enable = true;
     bluetooth.enable = true;
     catt.enable = true;
-    docker.enable = true;
+    docker = {
+      enable = true;
+      rootless.enable = false;
+    };
     graphics.enable = true;
     hyprland.enable = true;
     intel.enable = true;
+    k3s.enable = true;
     nvidia.enable = true;
     power-management.enable = true;
     sound.enable = true;

--- a/hosts/luna/default.nix
+++ b/hosts/luna/default.nix
@@ -1,5 +1,6 @@
 {
   inputs,
+  modulesPath,
   pkgs,
   self,
   ...
@@ -10,7 +11,7 @@ let
 in
 {
   imports = [
-    inputs.disko.nixosModules.disko
+    (modulesPath + "/installer/scan/not-detected.nix")
     ./disko.nix
     ./hardware-configuration.nix
     ../shared

--- a/hosts/luna/hardware-configuration.nix
+++ b/hosts/luna/hardware-configuration.nix
@@ -10,10 +10,6 @@
 }:
 
 {
-  imports = [
-    (modulesPath + "/installer/scan/not-detected.nix")
-  ];
-
   boot.initrd.availableKernelModules = [
     "xhci_pci"
     "nvme"

--- a/hosts/shared/default.nix
+++ b/hosts/shared/default.nix
@@ -1,5 +1,6 @@
-{ ... }:
+{ lib, ... }:
 
+with lib;
 {
   imports = [
     ./home-manager.nix
@@ -10,8 +11,10 @@
 
   services = {
     automatic-timezoned.enable = true;
-    geoclue2.geoProviderUrl = "https://beacondb.net/v1/geolocate";
-    # keyd - low level key remapping daemon
+    geoclue2 = {
+      enableDemoAgent = mkForce true; # FIXME: see https://github.com/NixOS/nixpkgs/issues/68489#issuecomment-1484030107
+      geoProviderUrl = "https://beacondb.net/v1/geolocate";
+    };
     keyd = {
       enable = true;
       keyboards.default.settings = {

--- a/hosts/shared/nix.nix
+++ b/hosts/shared/nix.nix
@@ -11,6 +11,7 @@
     settings = {
       accept-flake-config = true;
       auto-optimise-store = true;
+      download-buffer-size = 524288000; # 500MB
       experimental-features = [
         "nix-command"
         "flakes"

--- a/modules/docker.nix
+++ b/modules/docker.nix
@@ -21,14 +21,7 @@ with lib;
   };
 
   config = mkIf cfg.enable {
-    environment = {
-      #  TODO: docker should fallback to gnome-keyring by default
-      # systemPackages = with pkgs; [
-      #   docker-credential-helpers
-      # ];
-    };
-
-    hardware.nvidia-container-toolkit.enable = true;
+    hardware.nvidia-container-toolkit.enable = mkIf config.host.nvidia.enable true;
 
     virtualisation.docker = {
       enable = true;

--- a/modules/docker.nix
+++ b/modules/docker.nix
@@ -41,6 +41,12 @@ with lib;
       storageDriver = mkIf config.host.btrfs.enable "btrfs";
     };
 
+    networking = {
+      firewall.allowedTCPPorts = [
+        9003 # required so PHP XDebug can reach host machine
+      ];
+    };
+
     security.wrappers = mkIf config.host.docker.rootless.enable {
       docker-rootlesskit = {
         owner = "root";

--- a/modules/intel.nix
+++ b/modules/intel.nix
@@ -25,7 +25,6 @@ with lib;
       graphics = {
         extraPackages = with pkgs; [
           intel-compute-runtime # OpenCL for gen8 and beyond
-          intel-media-sdk # Quick Sync Video for older processors
           intel-media-driver # Accelerated Video Playback for Broadwell or newer processors. LIBVA_DRIVER_NAME=iHD
           # intel-vaapi-driver # Accelerated Video Playback for older processors. LIBVA_DRIVER_NAME=i965
         ];

--- a/modules/k3s.nix
+++ b/modules/k3s.nix
@@ -1,0 +1,27 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.host.k3s;
+in
+with lib;
+{
+  options = {
+    host.k3s.enable = mkEnableOption "k3s - lightweight Kubernetes distribution";
+  };
+
+  config = mkIf cfg.enable {
+    services.k3s = {
+      enable = true;
+      role = "server";
+      extraFlags = toString [
+        "--debug" # optional arguments
+      ];
+    };
+
+    networking.firewall = {
+      allowedTCPPorts = [
+        6443 # required so pods can reach API server
+      ];
+    };
+  };
+}

--- a/modules/k3s.nix
+++ b/modules/k3s.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   cfg = config.host.k3s;
@@ -10,16 +15,46 @@ with lib;
   };
 
   config = mkIf cfg.enable {
-    services.k3s = {
-      enable = true;
-      role = "server";
-      extraFlags = toString [
-        "--debug" # optional arguments
-      ];
+    environment.systemPackages = with pkgs; [
+      kubernetes-helm
+    ];
+
+    environment.etc."kube/config" = {
+      source = "/var/lib/rancher/k3s/server/cred/admin.kubeconfig";
+      target = "/home/shorty/.kube/config";
+      mode = "0600";
+      user = "shorty";
+      group = "users";
     };
 
-    networking.firewall = {
-      allowedTCPPorts = [
+    services.k3s = {
+      enable = true;
+      extraFlags = [
+        "--disable=traefik"
+        "--disable=servicelb"
+        "--docker"
+        "--write-kubeconfig-mode=0644"
+      ];
+      role = "server";
+      # autoDeployCharts = {
+      #   traefik = {
+      #     name = "traefik";
+      #     repo = "https://traefik.github.io/charts";
+      #     version = "36.1.0";
+      #     hash = "sha256-APQuQjKEpNwIaNi0RujZS1RcVLuPKC2PEXNLeM8/1F0=";
+      #     values = {
+      #       providers = {
+      #         kubernetesIngress.enabled = false;
+      #         kubernetesGateway.enabled = true;
+      #       };
+      #       gateway.namespacePolicy = "All";
+      #     };
+      #   };
+      # };
+    };
+
+    networking = {
+      firewall.allowedTCPPorts = [
         6443 # required so pods can reach API server
       ];
     };

--- a/modules/nvidia.nix
+++ b/modules/nvidia.nix
@@ -31,7 +31,7 @@ with lib;
       };
 
       nvidia = {
-        modesetting.enable = true;
+        modesetting.enable = true; # default since 535
         nvidiaSettings = true;
         open = false;
         package = config.boot.kernelPackages.nvidiaPackages.beta;

--- a/modules/openssh.nix
+++ b/modules/openssh.nix
@@ -30,6 +30,7 @@ with lib;
       settings = {
         MaxAuthTries = mkDefault 3;
         PermitRootLogin = mkDefault "no";
+        PasswordAuthentication = mkDefault false;
       };
     };
   };

--- a/modules/wayland.nix
+++ b/modules/wayland.nix
@@ -20,10 +20,6 @@ with lib;
     };
 
     security = {
-      # TODO: determine whether and how I want to use keyring when setting up yubikey support
-      # pam = {
-      #   services.gdm.enableGnomeKeyring = mkDefault true;
-      # };
       polkit.enable = mkDefault true;
     };
 

--- a/users/shorty/default.nix
+++ b/users/shorty/default.nix
@@ -33,6 +33,7 @@ with lib;
           "wheel"
         ]
         ++ ifTheyExist [
+          "docker"
           "libvirtd"
           "networkmanager"
           "openrazer"


### PR DESCRIPTION
Lightweight Kubernetes based on K3s. The intent is to have a single configuration that can be used for local development while staying as close to a production environment as possible.

This PR is the first step in that direction and will be refined while we build up experience working with Kubernetes using a simple cluster that employs the modern Gateway API over at: https://github.com/99linesofcode/kubernetes-base.

We might need to introduce MetalLB for load balancing purposes but to be honest, it's been a couple of months since I last looked at this and I need a refresher before I can say anything useful about that. Shipping this as is.